### PR TITLE
ブログ詳細画像はみ出しバグ修正

### DIFF
--- a/src/libs/html-react-parser/options.tsx
+++ b/src/libs/html-react-parser/options.tsx
@@ -13,6 +13,7 @@ import {
 	Tr,
 } from "@yamada-ui/react";
 import hljs from "highlight.js";
+import Image from "next/image";
 import "highlight.js/styles/atom-one-dark.css";
 import parse from "html-react-parser";
 import {
@@ -148,6 +149,16 @@ const replaceElements: Record<
 			</Box>
 		</blockquote>
 	),
+	img: ({ children, src, alt, ...props }) => {
+		return (
+			<Image
+				src={src}
+				alt={alt}
+				layout="intrinsic" // アスペクト比を自動計算
+				{...props}
+			/>
+		);
+	},
 };
 
 export const options: HTMLReactParserOptions = {


### PR DESCRIPTION
## 概要, 背景
<!-- このプルリクエストの目的や背景について簡潔に説明 -->
#69 の改善

## 変更内容
<!-- 実装内容や変更点の詳細を記載 -->
- next/imageのImageコンポーネントでラップしました。

## 関連するIssue
<!-- 関連するIssue番号があれば記載 -->
- Close #69  (関連Issue番号)
- Ref #69  (参照Issue番号)

## 変更理由
<!-- 変更を行った理由や、解決したかった課題について記載 -->
- ブログ詳細の画像は見出しを修正するために変更をおこないました。

## 影響範囲
<!-- この変更が影響する範囲やシステムへの影響を記載 -->
- ブログ詳細画像が画面外にはみ出なくなります。
修正後は、はみ出るような画像サイズのものであっても画像のようにきちんと収まります。
![image](https://github.com/user-attachments/assets/36c5b279-06da-4670-853c-78bef97a6904)


## チェックリスト
- [x] コードがビルドエラーなく実行できること
- [x] ドキュメント（READMEなど）が更新されていること
- [x] 環境変数を追加した場合、`.env.example` を更新していること

## 補足情報
<!-- その他、レビュアーに伝えておきたい情報があれば記載 -->
参考情報のURLです。
ChatGPT使ってサーチしましたが、一応...
https://nextjs.org/docs/pages/api-reference/components/image-legacy#width
https://nextjs.org/docs/pages/api-reference/components/image-legacy#height

一応自分なりに調べましたが、Imageタグのlayoutの設定をするだけでいいのか判断つきかねております。
動くには動くのですが、以下のように明示的にstyleを指定する形のほうがよいのかどうか...
```typescript
img: ({ children, src, alt, ...props }) => {
  const combinedStyle = {
      maxWidth: '100%',
      maxHeight: '100%',
      width: 'auto',       // 自動調整でアスペクト比を維持
      height: 'auto',
      ...style
  };

  return <Image src={src} alt={alt} style={combinedStyle} {...props} />;
}
```