### PR TITLE
お問い合わせのメールアドレスをGoogleフォームに変更

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -80,10 +80,14 @@ export default function Home() {
 				</Heading>
 				<Text>
 					ご質問等がございましたら、お気軽に{" "}
-					<Link href="mailto:yumekobo.ddp@gmail.com" color="blue.500">
-						yumekobo.ddp@gmail.com
+					<Link
+						href="https://forms.gle/mkyGNmE4JDkCaBQs8"
+						color="blue.500"
+						isExternal
+					>
+						お問い合わせフォーム
 					</Link>{" "}
-					までお問い合わせください。
+					からお問い合わせください。
 				</Text>
 			</Section>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -62,8 +62,8 @@ const sns = [
 	},
 	{
 		Icon: <IconMail />,
-		href: "mailto:yumekobo.ddp@gmail.com",
-		label: "Email",
+		href: "https://forms.gle/mkyGNmE4JDkCaBQs8",
+		label: "お問い合わせ",
 	},
 ];
 


### PR DESCRIPTION
## Summary
- お問い合わせページとFooterのメールアドレス直接表示をやめ、Google Formsへのリンクに変更
- スパム対策としてメールアドレスの公開を停止
- Closes #102 

## Test plan
- [x] お問い合わせページのリンクからGoogle Formsが開けること
- [x] FooterのメールアイコンからGoogle Formsが開けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)